### PR TITLE
feat: Add configurable image preprocessing pipeline

### DIFF
--- a/backend/document/tests/processing.test.ts
+++ b/backend/document/tests/processing.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { process as processHandler } from "../process";
+import { documentDB } from "../db";
+import { originalImages, processedDocuments } from "../storage";
+import { processImageToStructure } from "../processors";
+
+// Mock dependencies
+vi.mock("../db", () => ({
+  documentDB: {
+    exec: vi.fn(),
+    queryRow: vi.fn(),
+  },
+}));
+
+vi.mock("../storage", () => ({
+  originalImages: {
+    download: vi.fn(),
+  },
+  processedDocuments: {
+    upload: vi.fn(),
+  },
+}));
+
+vi.mock("../processors", () => ({
+  processImageToStructure: vi.fn(),
+}));
+
+const mockSharpInstance = {
+  deskew: vi.fn().mockReturnThis(),
+  denoise: vi.fn().mockReturnThis(),
+  threshold: vi.fn().mockReturnThis(),
+  toColorspace: vi.fn().mockReturnThis(),
+  linear: vi.fn().mockReturnThis(),
+  sharpen: vi.fn().mockReturnThis(),
+  normalize: vi.fn().mockReturnThis(),
+  jpeg: vi.fn().mockReturnThis(),
+  toBuffer: vi.fn().mockResolvedValue(Buffer.from("processed-image")),
+};
+
+// Mock sharp conditionally, as it's an optional dependency
+try {
+  vi.mock("sharp", () => ({
+    __esModule: true,
+    default: vi.fn(() => mockSharpInstance),
+  }));
+} catch (e) {
+  // sharp not installed, which is fine in some environments
+}
+
+
+describe("Image Preprocessing Pipeline", () => {
+
+  beforeEach(() => {
+    // Mock default return values for dependencies
+    (documentDB.queryRow as any).mockResolvedValue({
+      id: "test-doc-id",
+      original_filename: "test.png",
+      mime_type: "image/png",
+    });
+    (originalImages.download as any).mockResolvedValue(Buffer.from("original-image-buffer"));
+    (processImageToStructure as any).mockResolvedValue({
+      text: "extracted text",
+      structure: { metadata: { dimensions: { width: 100, height: 100 } }, elements: [] },
+      language: "eng",
+      confidence: 95,
+      ocrProvider: "tesseract",
+    });
+    (documentDB.exec as any).mockResolvedValue({ rows: [], rowCount: 1 });
+    (processedDocuments.upload as any).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should not call any preprocessing methods if options are not provided", async () => {
+    const req = { documentId: "test-doc-id" };
+    await processHandler(req as any);
+
+    expect(mockSharpInstance.deskew).not.toHaveBeenCalled();
+    expect(mockSharpInstance.denoise).not.toHaveBeenCalled();
+    expect(mockSharpInstance.threshold).not.toHaveBeenCalled();
+  });
+
+  it("should call deskew() when preprocessing.deskew is true", async () => {
+    const req = {
+      documentId: "test-doc-id",
+      preprocessing: { deskew: true },
+    };
+    await processHandler(req as any);
+
+    expect(mockSharpInstance.deskew).toHaveBeenCalledTimes(1);
+    expect(mockSharpInstance.denoise).not.toHaveBeenCalled();
+    expect(mockSharpInstance.threshold).not.toHaveBeenCalled();
+  });
+
+  it("should call denoise() when preprocessing.denoise is true", async () => {
+    const req = {
+      documentId: "test-doc-id",
+      preprocessing: { denoise: true },
+    };
+    await processHandler(req as any);
+
+    expect(mockSharpInstance.denoise).toHaveBeenCalledTimes(1);
+    expect(mockSharpInstance.deskew).not.toHaveBeenCalled();
+    expect(mockSharpInstance.threshold).not.toHaveBeenCalled();
+  });
+
+  it("should call threshold() for binarization when preprocessing.binarize is true", async () => {
+    const req = {
+      documentId: "test-doc-id",
+      preprocessing: { binarize: true },
+    };
+    await processHandler(req as any);
+
+    expect(mockSharpInstance.threshold).toHaveBeenCalledTimes(1);
+    expect(mockSharpInstance.deskew).not.toHaveBeenCalled();
+    expect(mockSharpInstance.denoise).not.toHaveBeenCalled();
+  });
+
+  it("should call all specified preprocessing methods", async () => {
+    const req = {
+      documentId: "test-doc-id",
+      preprocessing: {
+        deskew: true,
+        denoise: true,
+        binarize: true,
+      },
+    };
+    await processHandler(req as any);
+
+    expect(mockSharpInstance.deskew).toHaveBeenCalledTimes(1);
+    expect(mockSharpInstance.denoise).toHaveBeenCalledTimes(1);
+    expect(mockSharpInstance.threshold).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
This commit implements an advanced, configurable image preprocessing pipeline that runs before the OCR step. This addresses the user's request to add image enhancement capabilities to improve OCR accuracy.

The pipeline is built on the existing `sharp` library and adds the following optional steps, which can be controlled via the API:
- Deskewing (`deskew: true`)
- Denoising (`denoise: true`)
- Binarization (`binarize: true`)

These options can be passed in a `preprocessing` object in the request to the `POST /document/:documentId/process` endpoint.

A comprehensive suite of unit tests has been added in `backend/document/tests/processing.test.ts` to verify the new logic. The tests use mocking to ensure the correct `sharp` methods are called based on the request parameters.

Note: The test suite could not be run to completion due to a persistent issue with the test environment (missing `ENCORE_RUNTIME_LIB`). The feature is being submitted with the new tests, with the assumption that they will pass in a correctly configured Encore environment.