### PR TITLE
fix: Correct API endpoint definitions and resolve route conflicts

### DIFF
--- a/backend/document/templates_create.ts
+++ b/backend/document/templates_create.ts
@@ -11,7 +11,7 @@ interface CreateTemplateRequest {
 
 // Creates a new document matching template.
 export const createTemplate = api<CreateTemplateRequest, DocumentMatchingTemplate>(
-  { expose: true, method: "POST", path: "/templates" },
+  { expose: true, method: "POST", path: "/document-templates" },
   async (req) => {
     if (!req.name) {
       throw APIError.invalidArgument("template name is required");

--- a/backend/document/templates_delete.ts
+++ b/backend/document/templates_delete.ts
@@ -1,18 +1,23 @@
 import { api } from "encore.dev/api";
 import { documentDB } from "./db";
 
+interface DeleteTemplateParams {
+  templateId: string;
+}
+
 interface DeleteResponse {
   status: "ok";
 }
 
 // Deletes a document matching template by ID.
-export const deleteTemplate = api.delete<DeleteResponse>("/templates/:templateId", async ({ params }) => {
-  const templateId = params.templateId;
+export const deleteTemplate = api<DeleteTemplateParams, DeleteResponse>(
+  { expose: true, method: "DELETE", path: "/document-templates/:templateId" },
+  async ({ templateId }) => {
+    await documentDB.exec`
+      DELETE FROM document_templates
+      WHERE id = ${templateId}
+    `;
 
-  await documentDB.exec`
-    DELETE FROM document_templates
-    WHERE id = ${templateId}
-  `;
-
-  return { status: "ok" };
-});
+    return { status: "ok" };
+  }
+);

--- a/backend/document/templates_get.ts
+++ b/backend/document/templates_get.ts
@@ -2,28 +2,33 @@ import { api, APIError } from "encore.dev/api";
 import { documentDB } from "./db";
 import type { DocumentMatchingTemplate, TemplateROI } from "./types";
 
+interface GetTemplateParams {
+  templateId: string;
+}
+
 // Gets a single document matching template by ID.
-export const getTemplate = api.get<DocumentMatchingTemplate>("/templates/:templateId", async ({ params }) => {
-  const templateId = params.templateId;
+export const getTemplate = api<GetTemplateParams, DocumentMatchingTemplate>(
+  { expose: true, method: "GET", path: "/document-templates/:templateId" },
+  async ({ templateId }) => {
+    const templateData = await documentDB.queryRow<Omit<DocumentMatchingTemplate, "rois">>`
+      SELECT id, name, description, match_fingerprint, created_at, updated_at
+      FROM document_templates
+      WHERE id = ${templateId}
+    `;
 
-  const templateData = await documentDB.queryRow<Omit<DocumentMatchingTemplate, "rois">>`
-    SELECT id, name, description, match_fingerprint, created_at, updated_at
-    FROM document_templates
-    WHERE id = ${templateId}
-  `;
+    if (!templateData) {
+      throw APIError.notFound("template not found");
+    }
 
-  if (!templateData) {
-    throw APIError.notFound("template not found");
+    const roisResult = await documentDB.query<TemplateROI>`
+      SELECT id, name, x, y, width, height
+      FROM template_rois
+      WHERE template_id = ${templateId}
+    `;
+
+    return {
+      ...templateData,
+      rois: roisResult.rows,
+    };
   }
-
-  const roisResult = await documentDB.query<TemplateROI>`
-    SELECT id, name, x, y, width, height
-    FROM template_rois
-    WHERE template_id = ${templateId}
-  `;
-
-  return {
-    ...templateData,
-    rois: roisResult.rows,
-  };
-});
+);

--- a/backend/document/templates_list.ts
+++ b/backend/document/templates_list.ts
@@ -7,11 +7,14 @@ interface ListTemplatesResponse {
 }
 
 // Lists all document matching templates.
-export const listTemplates = api.get<ListTemplatesResponse>("/templates", async () => {
-  const result = await documentDB.query<Omit<DocumentMatchingTemplate, "rois">>`
-    SELECT id, name, description, match_fingerprint, created_at, updated_at
-    FROM document_templates
-    ORDER BY created_at DESC
-  `;
-  return { templates: result.rows };
-});
+export const listTemplates = api<void, ListTemplatesResponse>(
+  { expose: true, method: "GET", path: "/document-templates" },
+  async () => {
+    const result = await documentDB.query<Omit<DocumentMatchingTemplate, "rois">>`
+      SELECT id, name, description, match_fingerprint, created_at, updated_at
+      FROM document_templates
+      ORDER BY created_at DESC
+    `;
+    return { templates: result.rows };
+  }
+);

--- a/backend/document/templates_update.ts
+++ b/backend/document/templates_update.ts
@@ -2,62 +2,71 @@ import { api, APIError } from "encore.dev/api";
 import { documentDB } from "./db";
 import type { DocumentMatchingTemplate, TemplateROI } from "./types";
 
-interface UpdateTemplateRequest {
+interface UpdateTemplateBody {
   name: string;
   description?: string;
   matchFingerprint: string;
   rois: Array<Omit<TemplateROI, "id">>;
 }
 
+interface UpdateTemplateParams {
+  templateId: string;
+}
+
+type UpdateTemplateRequest = UpdateTemplateBody & UpdateTemplateParams;
+
 // Updates a document matching template.
-export const updateTemplate = api.put<DocumentMatchingTemplate>("/templates/:templateId", async ({ params, body }) => {
-  const templateId = params.templateId;
+export const updateTemplate = api<UpdateTemplateRequest, DocumentMatchingTemplate>(
+  { expose: true, method: "PUT", path: "/document-templates/:templateId" },
+  async (req) => {
+    const { templateId, name, description, matchFingerprint, rois: reqRois } = req;
 
-  if (!body.name) {
-    throw APIError.invalidArgument("template name is required");
-  }
-  if (!body.matchFingerprint) {
-    throw APIError.invalidArgument("template matchFingerprint is required");
-  }
-  if (!body.rois || body.rois.length === 0) {
-    throw APIError.invalidArgument("template must have at least one ROI");
-  }
-
-  const template = await documentDB.tx(async (db) => {
-    // Update the parent template record
-    const templateResult = await db.queryRow<any>`
-      UPDATE document_templates
-      SET name = ${body.name}, description = ${body.description ?? null}, match_fingerprint = ${body.matchFingerprint}, updated_at = NOW()
-      WHERE id = ${templateId}
-      RETURNING id, name, description, created_at, updated_at
-    `;
-
-    if (!templateResult) {
-      throw APIError.notFound("template not found");
+    if (!name) {
+      throw APIError.invalidArgument("template name is required");
+    }
+    if (!matchFingerprint) {
+      throw APIError.invalidArgument("template matchFingerprint is required");
+    }
+    if (!reqRois || reqRois.length === 0) {
+      throw APIError.invalidArgument("template must have at least one ROI");
     }
 
-    // Delete existing ROIs
-    await db.exec`
-      DELETE FROM template_rois
-      WHERE template_id = ${templateId}
-    `;
-
-    // Insert the new ROIs
-    const rois: TemplateROI[] = [];
-    for (const roi of body.rois) {
-      const roiResult = await db.queryRow<any>`
-        INSERT INTO template_rois (template_id, name, x, y, width, height)
-        VALUES (${templateId}, ${roi.name}, ${roi.x}, ${roi.y}, ${roi.width}, ${roi.height})
-        RETURNING id, name, x, y, width, height
+    const template = await documentDB.tx(async (db) => {
+      // Update the parent template record
+      const templateResult = await db.queryRow<any>`
+        UPDATE document_templates
+        SET name = ${name}, description = ${description ?? null}, match_fingerprint = ${matchFingerprint}, updated_at = NOW()
+        WHERE id = ${templateId}
+        RETURNING id, name, description, created_at, updated_at
       `;
-      rois.push(roiResult);
-    }
 
-    return {
-      ...templateResult,
-      rois,
-    };
-  });
+      if (!templateResult) {
+        throw APIError.notFound("template not found");
+      }
 
-  return template;
-});
+      // Delete existing ROIs
+      await db.exec`
+        DELETE FROM template_rois
+        WHERE template_id = ${templateId}
+      `;
+
+      // Insert the new ROIs
+      const rois: TemplateROI[] = [];
+      for (const roi of reqRois) {
+        const roiResult = await db.queryRow<any>`
+          INSERT INTO template_rois (template_id, name, x, y, width, height)
+          VALUES (${templateId}, ${roi.name}, ${roi.x}, ${roi.y}, ${roi.width}, ${roi.height})
+          RETURNING id, name, x, y, width, height
+        `;
+        rois.push(roiResult);
+      }
+
+      return {
+        ...templateResult,
+        rois,
+      };
+    });
+
+    return template;
+  }
+);

--- a/backend/document/versions_get.ts
+++ b/backend/document/versions_get.ts
@@ -2,6 +2,11 @@ import { api, APIError } from "encore.dev/api";
 import { documentDB } from "./db";
 import type { DocumentStructure } from "./types";
 
+interface GetVersionParams {
+  documentId: string;
+  versionId: string;
+}
+
 interface GetVersionResponse {
   documentId: string;
   versionId: string;
@@ -9,22 +14,23 @@ interface GetVersionResponse {
 }
 
 // Gets the document structure for a specific version.
-export const getVersion = api.get<GetVersionResponse>("/documents/:documentId/versions/:versionId", async ({ params }) => {
-  const { documentId, versionId } = params;
+export const getVersion = api<GetVersionParams, GetVersionResponse>(
+  { expose: true, method: "GET", path: "/documents/:documentId/versions/:versionId" },
+  async ({ documentId, versionId }) => {
+    const result = await documentDB.queryRow<{ document_structure: DocumentStructure }>`
+      SELECT document_structure
+      FROM document_versions
+      WHERE document_id = ${documentId} AND id = ${versionId}
+    `;
 
-  const result = await documentDB.queryRow<{ document_structure: DocumentStructure }>`
-    SELECT document_structure
-    FROM document_versions
-    WHERE document_id = ${documentId} AND id = ${versionId}
-  `;
+    if (!result) {
+      throw APIError.notFound("version not found");
+    }
 
-  if (!result) {
-    throw APIError.notFound("version not found");
+    return {
+      documentId,
+      versionId,
+      documentStructure: result.document_structure,
+    };
   }
-
-  return {
-    documentId,
-    versionId,
-    documentStructure: result.document_structure,
-  };
-});
+);

--- a/backend/document/versions_list.ts
+++ b/backend/document/versions_list.ts
@@ -12,14 +12,20 @@ interface ListVersionsResponse {
   versions: VersionInfo[];
 }
 
+interface ListVersionsParams {
+  documentId: string;
+}
+
 // Lists all available versions for a document.
-export const listVersions = api.get<ListVersionsResponse>("/documents/:documentId/versions", async ({ params }) => {
-  const documentId = params.documentId;
-  const result = await documentDB.query<VersionInfo>`
-    SELECT id, version_number, created_at
-    FROM document_versions
-    WHERE document_id = ${documentId}
-    ORDER BY version_number DESC
-  `;
-  return { versions: result.rows };
-});
+export const listVersions = api<ListVersionsParams, ListVersionsResponse>(
+  { expose: true, method: "GET", path: "/documents/:documentId/versions" },
+  async ({ documentId }) => {
+    const result = await documentDB.query<VersionInfo>`
+      SELECT id, version_number, created_at
+      FROM document_versions
+      WHERE document_id = ${documentId}
+      ORDER BY version_number DESC
+    `;
+    return { versions: result.rows };
+  }
+);

--- a/frontend/client.ts
+++ b/frontend/client.ts
@@ -96,6 +96,11 @@ import {
     listTemplates as api_document_templates_listTemplates,
     upsertTemplate as api_document_templates_upsertTemplate
 } from "~backend/document/templates";
+import { createTemplate as api_document_templates_create_createTemplate } from "~backend/document/templates_create";
+import { deleteTemplate as api_document_templates_delete_deleteTemplate } from "~backend/document/templates_delete";
+import { getTemplate as api_document_templates_get_getTemplate } from "~backend/document/templates_get";
+import { listTemplates as api_document_templates_list_listTemplates } from "~backend/document/templates_list";
+import { updateTemplate as api_document_templates_update_updateTemplate } from "~backend/document/templates_update";
 import { updateDocument as api_document_update_updateDocument } from "~backend/document/update";
 import { upload as api_document_upload_upload } from "~backend/document/upload";
 import { listVersions as api_document_versions_list_listVersions } from "~backend/document/versions_list";
@@ -114,10 +119,14 @@ export namespace document {
             this.batchProcessStream = this.batchProcessStream.bind(this)
             this.compare = this.compare.bind(this)
             this.convert = this.convert.bind(this)
+            this.createDocumentTemplate = this.createDocumentTemplate.bind(this)
+            this.deleteDocumentTemplate = this.deleteDocumentTemplate.bind(this)
             this.get = this.get.bind(this)
             this.getDashboard = this.getDashboard.bind(this)
+            this.getDocumentTemplate = this.getDocumentTemplate.bind(this)
             this.getVersion = this.getVersion.bind(this)
             this.list = this.list.bind(this)
+            this.listDocumentTemplates = this.listDocumentTemplates.bind(this)
             this.listOutputs = this.listOutputs.bind(this)
             this.listTemplates = this.listTemplates.bind(this)
             this.listVersions = this.listVersions.bind(this)
@@ -126,6 +135,7 @@ export namespace document {
             this.spellcheck = this.spellcheck.bind(this)
             this.translate = this.translate.bind(this)
             this.updateDocument = this.updateDocument.bind(this)
+            this.updateDocumentTemplate = this.updateDocumentTemplate.bind(this)
             this.upload = this.upload.bind(this)
             this.upsertTemplate = this.upsertTemplate.bind(this)
         }
@@ -173,6 +183,22 @@ export namespace document {
         }
 
         /**
+         * Creates a new document matching template.
+         */
+        public async createDocumentTemplate(params: RequestType<typeof api_document_templates_create_createTemplate>): Promise<ResponseType<typeof api_document_templates_create_createTemplate>> {
+            const resp = await this.baseClient.callTypedAPI(`/document-templates`, {method: "POST", body: JSON.stringify(params)})
+            return JSON.parse(await resp.text(), dateReviver) as ResponseType<typeof api_document_templates_create_createTemplate>
+        }
+
+        /**
+         * Deletes a document matching template by ID.
+         */
+        public async deleteDocumentTemplate(params: { templateId: string }): Promise<ResponseType<typeof api_document_templates_delete_deleteTemplate>> {
+            const resp = await this.baseClient.callTypedAPI(`/document-templates/${encodeURIComponent(params.templateId)}`, {method: "DELETE", body: undefined})
+            return JSON.parse(await resp.text(), dateReviver) as ResponseType<typeof api_document_templates_delete_deleteTemplate>
+        }
+
+        /**
          * Retrieves document information by ID.
          */
         public async get(params: { id: string }): Promise<ResponseType<typeof api_document_get_get>> {
@@ -188,6 +214,14 @@ export namespace document {
             // Now make the actual call to the API
             const resp = await this.baseClient.callTypedAPI(`/metrics/dashboard`, {method: "GET", body: undefined})
             return JSON.parse(await resp.text(), dateReviver) as ResponseType<typeof api_document_metrics_getDashboard>
+        }
+
+        /**
+         * Gets a single document matching template by ID.
+         */
+        public async getDocumentTemplate(params: { templateId: string }): Promise<ResponseType<typeof api_document_templates_get_getTemplate>> {
+            const resp = await this.baseClient.callTypedAPI(`/document-templates/${encodeURIComponent(params.templateId)}`, {method: "GET", body: undefined})
+            return JSON.parse(await resp.text(), dateReviver) as ResponseType<typeof api_document_templates_get_getTemplate>
         }
 
         /**
@@ -212,6 +246,14 @@ export namespace document {
             // Now make the actual call to the API
             const resp = await this.baseClient.callTypedAPI(`/documents`, {query, method: "GET", body: undefined})
             return JSON.parse(await resp.text(), dateReviver) as ResponseType<typeof api_document_list_list>
+        }
+
+        /**
+         * Lists all document matching templates.
+         */
+        public async listDocumentTemplates(): Promise<ResponseType<typeof api_document_templates_list_listTemplates>> {
+            const resp = await this.baseClient.callTypedAPI(`/document-templates`, {method: "GET", body: undefined})
+            return JSON.parse(await resp.text(), dateReviver) as ResponseType<typeof api_document_templates_list_listTemplates>
         }
 
         /**
@@ -303,6 +345,20 @@ export namespace document {
             // Now make the actual call to the API
             const resp = await this.baseClient.callTypedAPI(`/document/${encodeURIComponent(params.id)}`, {method: "PUT", body: JSON.stringify(body)})
             return JSON.parse(await resp.text(), dateReviver) as ResponseType<typeof api_document_update_updateDocument>
+        }
+
+        /**
+         * Updates a document matching template.
+         */
+        public async updateDocumentTemplate(params: RequestType<typeof api_document_templates_update_updateTemplate>): Promise<ResponseType<typeof api_document_templates_update_updateTemplate>> {
+            const body: Record<string, any> = {
+                name: params.name,
+                description: params.description,
+                matchFingerprint: params.matchFingerprint,
+                rois: params.rois,
+            }
+            const resp = await this.baseClient.callTypedAPI(`/document-templates/${encodeURIComponent(params.templateId)}`, {method: "PUT", body: JSON.stringify(body)})
+            return JSON.parse(await resp.text(), dateReviver) as ResponseType<typeof api_document_templates_update_updateTemplate>
         }
 
         /**


### PR DESCRIPTION
This commit fixes a series of errors that were causing the application build to fail.

The fixes include:
- **Resolving Route Conflict:** The API endpoints for the new Document Matching Template feature have been moved from `/templates` to `/document-templates`. This resolves a conflict with a pre-existing API for styling templates.
- **Correcting API Syntax:** All newly created API endpoints (`templates_*` and `versions_*`) have been updated to use the correct object literal syntax required by the Encore framework, fixing the `expected object literal` build error.
- **Updating Frontend Client:** The frontend API client has been manually updated to reflect these backend changes, ensuring that the new endpoints are callable from the UI.

This commit addresses the build errors and brings the recently added features into a correct and working state.